### PR TITLE
bugfix - update readme use default awscli envvars

### DIFF
--- a/charts/s3-service-provider/README.md
+++ b/charts/s3-service-provider/README.md
@@ -1,1 +1,1 @@
-helm install . --set AdminAwsAccessKeyId=${AWS_ACCESS_KEY_ID},AdminAwsSecretAccessKey=${AWS_SECRET_ACCESS_KEY} --namespace steward --replace
+`helm install . --set AdminAwsAccessKeyId=${AWS_ACCESS_KEY_ID},AdminAwsSecretAccessKey=${AWS_SECRET_ACCESS_KEY} --namespace steward --replace`


### PR DESCRIPTION
Use default envvars according to http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-environment
