### PR TITLE
fix(templates): de-quote replicas in manifests

### DIFF
--- a/charts/s3-service-provider/templates/broker.yaml
+++ b/charts/s3-service-provider/templates/broker.yaml
@@ -41,7 +41,7 @@ metadata:
   annotations:
     "helm.sh/created": {{.Release.Time.Seconds | quote }}
 spec:
-  replicas: {{default 1 .Values.Replicas | quote }}
+  replicas: {{ default 1 .Values.Replicas }}
   template:
     metadata:
       name: "{{ printf "%s-broker" .Release.Name | trunc 24 }}"

--- a/charts/s3-service-provider/templates/steward.yaml
+++ b/charts/s3-service-provider/templates/steward.yaml
@@ -28,7 +28,7 @@ metadata:
   annotations:
     "helm.sh/created": {{.Release.Time.Seconds | quote }}
 spec:
-  replicas: {{default 1 .Values.Replicas | quote }}
+  replicas: {{ default 1 .Values.Replicas }}
   template:
     metadata:
       name: "{{ printf "%s-steward" .Release.Name | trunc 24 }}"


### PR DESCRIPTION
After upgrading to Helm Alpha.5 I experienced:

``` console
$ helm install --set AdminAwsAccessKeyId=${AWS_ACCESS_KEY_ID},AdminAwsSecretAccessKey=${AWS_SECRET_ACCESS_KEY} --namespace steward --name s3provider .
Error: release s3provider failed: [unable to decode "": [pos 286]: json: decNum: got first char '"', unable to decode "": [pos 284]: json: decNum: got first char '"']
```

This PR resolved the issue.
